### PR TITLE
feat: aside component render error in island mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+
+
+## [0.1.2](https://github.com/sanyuan0704/island.js/compare/0.1.1...0.1.2) (2022-09-18)
+
+
+### Bug Fixes
+
+* aside component render error in island mode ([0f80aab](https://github.com/sanyuan0704/island.js/commit/0f80aab6cb1bdca7e6d485835e759f7ff6b10f85))
+
 ## 0.1.1 (2022-09-18)
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "islandjs",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Vite & Islands architecture SSG framework",
   "main": "dist/index.js",
   "packageManager": "pnpm@7.9.2",

--- a/src/node/build.ts
+++ b/src/node/build.ts
@@ -148,7 +148,7 @@ class SSGBuilder {
   async islandsBuild(injectCode: string) {
     return this.#baseBuild(false, {
       build: {
-        minify: true,
+        minify: !process.env.DEBUG,
         outDir: TEMP_PATH,
         ssrManifest: false,
         rollupOptions: {

--- a/src/theme-default/logic/useAsideAnchor.ts
+++ b/src/theme-default/logic/useAsideAnchor.ts
@@ -18,7 +18,15 @@ export function useAsideAnchor(
   asideRef: React.MutableRefObject<HTMLDivElement | null>,
   markerRef: React.MutableRefObject<HTMLDivElement | null>
 ) {
-  const { pathname } = useLocation();
+  let pathname;
+  if (import.meta.env.ENABLE_SPA) {
+    // Notice: useLocation is not available in Island mode
+    // Whether to set enableSpa or not, the hook execute order is always the same
+    // So we can tree shaking the react-router-dom code in island mode and there is no hook order problem
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const location = useLocation();
+    pathname = location.pathname;
+  }
   useEffect(() => {
     if (!headers.length && markerRef.current) {
       markerRef.current.style.opacity = '0';
@@ -86,10 +94,14 @@ export function useAsideAnchor(
     };
   }, [asideRef, headers, headers.length, markerRef, prevActiveLinkRef]);
 
-  useEffect(() => {
-    if (markerRef.current) {
-      markerRef.current.style.opacity = '0';
-      window.scrollTo(0, 0);
-    }
-  }, [markerRef, pathname]);
+  useEffect(
+    () => {
+      if (markerRef.current) {
+        markerRef.current.style.opacity = '0';
+        window.scrollTo(0, 0);
+      }
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    import.meta.env.ENABLE_SPA ? [markerRef, pathname] : [markerRef]
+  );
 }


### PR DESCRIPTION
Because of that aside component use `useLocation` API from `react-router-dom`, which can only be used in spa mode.So in mpa(island) mode, we tree shaking relavant code about useLocation.

![image](https://user-images.githubusercontent.com/39261479/190891803-8c996c08-f7ec-431d-b901-9367ff186bdb.png)
