### PR TITLE
fix: nodejs14不可用 replaceAll

### DIFF
--- a/src/node/build.ts
+++ b/src/node/build.ts
@@ -243,7 +243,7 @@ class SSGBuilder {
         {
           "imports": {
             ${DEFAULT_EXTERNALS.map(
-              (name) => `"${name}": "/${name.replaceAll('/', '_')}.js"`
+              (name) => `"${name}": "/${name.replace(/\//g, '_')}.js"`
             ).join(',')}
           }
         }


### PR DESCRIPTION
node version: 14.19.1

command: pnpm dev:docs

errors:
```
.replaceAll is not a function 
不可用 replaceAll
```
