### PR TITLE
fix: fix separator when use window, it will make vite wrong

### DIFF
--- a/src/node/plugin-routes/index.ts
+++ b/src/node/plugin-routes/index.ts
@@ -2,6 +2,7 @@ import path from 'path';
 import { PageModule } from '../../shared/types';
 import type { Plugin } from 'vite';
 import { RouteService } from './RouteService';
+import { toSeq } from '../utils';
 
 /**
  * How does the conventional route work?
@@ -52,7 +53,7 @@ export function pluginRoutes(options: PluginOptions = {}): Plugin {
       scanDir = path.isAbsolute(root)
         ? path.join(root, prefix)
         : path.join(process.cwd(), root, prefix);
-      routeService = new RouteService(scanDir, extensions);
+      routeService = new RouteService(toSeq(scanDir), extensions);
       await routeService.init();
     },
 

--- a/src/node/plugin-routes/index.ts
+++ b/src/node/plugin-routes/index.ts
@@ -2,7 +2,7 @@ import path from 'path';
 import { PageModule } from '../../shared/types';
 import type { Plugin } from 'vite';
 import { RouteService } from './RouteService';
-import { toSeq } from '../utils';
+import { normalizePath } from '../utils';
 
 /**
  * How does the conventional route work?
@@ -53,7 +53,7 @@ export function pluginRoutes(options: PluginOptions = {}): Plugin {
       scanDir = path.isAbsolute(root)
         ? path.join(root, prefix)
         : path.join(process.cwd(), root, prefix);
-      routeService = new RouteService(toSeq(scanDir), extensions);
+      routeService = new RouteService(normalizePath(scanDir), extensions);
       await routeService.init();
     },
 

--- a/src/node/utils.ts
+++ b/src/node/utils.ts
@@ -12,6 +12,6 @@ export const createHash = (info: string): string => {
   return createHashFunc('sha256').update(info).digest('hex').slice(0, 8);
 };
 
-export const toSeq = (url: string, sep = '/') => {
+export const normalizePath = (url: string, sep = '/') => {
   return url.replace(/\\/g, sep);
 };

--- a/src/node/utils.ts
+++ b/src/node/utils.ts
@@ -11,3 +11,7 @@ export const createHash = (info: string): string => {
   }
   return createHashFunc('sha256').update(info).digest('hex').slice(0, 8);
 };
+
+export const toSeq = (url: string, sep = '/') => {
+  return url.replace(/\\/g, sep);
+}

--- a/src/node/utils.ts
+++ b/src/node/utils.ts
@@ -14,4 +14,4 @@ export const createHash = (info: string): string => {
 
 export const toSeq = (url: string, sep = '/') => {
   return url.replace(/\\/g, sep);
-}
+};


### PR DESCRIPTION
platform： window

when use window：
![image](https://user-images.githubusercontent.com/31154493/191339885-b9c6afa0-acfb-4370-ae58-b1995a307a8d.png)

and i find vite will resolve path:
![image](https://user-images.githubusercontent.com/31154493/191340032-c5eba88a-5f26-41a6-a1ea-30daf7d7d4aa.png)

we need resolve url when use window