### PR TITLE
fix: nav background styles in dark mode

### DIFF
--- a/src/theme-default/components/Nav/index.module.scss
+++ b/src/theme-default/components/Nav/index.module.scss
@@ -13,10 +13,6 @@
     backdrop-filter: saturate(50%) blur(8px);
   }
 
-  :global(.dark) .nav {
-    background: rgba(36, 36, 36, 0.7);
-  }
-
   @supports not (backdrop-filter: saturate(50%) blur(8px)) {
     .nav {
       background: rgba(255, 255, 255, 0.95);


### PR DESCRIPTION
The background color of `Nav` component has unexpected behavior in dark mode. Image below was a screenshot from the official docs site of [island](https://island.sanyuan0704.top/guide/getting-started.html)
![image](https://user-images.githubusercontent.com/73387709/192477291-3418bf12-50c1-420d-97ca-959dd8c650cd.png)

The background color of left side of the `Nav` component was just different