### PR TITLE
feat: show last updated time

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,6 @@
     "vite-plugin-inspect": "^0.7.1"
   },
   "devDependencies": {
-    "pnpm": "7.9.2",
     "@babel/traverse": "^7.19.0",
     "@commitlint/cli": "^17.1.2",
     "@commitlint/config-conventional": "^17.1.0",
@@ -123,10 +122,12 @@
     "eslint-plugin-react": "^7.31.1",
     "eslint-plugin-react-hooks": "^4.6.0",
     "lint-staged": "^13.0.3",
+    "pnpm": "7.9.2",
     "prettier": "^2.7.1",
     "release-it": "^15.4.2",
     "resolve": "^1.22.1",
     "rollup": "^2.78.1",
+    "simple-git": "^3.14.1",
     "tsup": "^6.2.3",
     "tsx": "^3.8.2",
     "typescript": "^4.7.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,6 +72,7 @@ specifiers:
   rollup: ^2.78.1
   sass: ^1.54.5
   shiki: ^0.11.1
+  simple-git: ^3.14.1
   sirv: ^2.0.2
   tsup: ^6.2.3
   tsx: ^3.8.2
@@ -163,6 +164,7 @@ devDependencies:
   release-it: 15.4.2
   resolve: 1.22.1
   rollup: 2.78.1
+  simple-git: 3.14.1
   tsup: 6.2.3_typescript@4.7.4
   tsx: 3.8.2
   typescript: 4.7.4
@@ -764,6 +766,18 @@ packages:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.0
       '@jridgewell/sourcemap-codec': 1.4.14
+    dev: true
+
+  /@kwsites/file-exists/1.1.1:
+    resolution: {integrity: sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==}
+    dependencies:
+      debug: 4.3.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@kwsites/promise-deferred/1.1.1:
+    resolution: {integrity: sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==}
     dev: true
 
   /@mdx-js/mdx/2.1.3:
@@ -6795,6 +6809,16 @@ packages:
 
   /signal-exit/3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
+
+  /simple-git/3.14.1:
+    resolution: {integrity: sha512-1ThF4PamK9wBORVGMK9HK5si4zoGS2GpRO7tkAFObA4FZv6dKaCVHLQT+8zlgiBm6K2h+wEU9yOaFCu/SR3OyA==}
+    dependencies:
+      '@kwsites/file-exists': 1.1.1
+      '@kwsites/promise-deferred': 1.1.1
+      debug: 4.3.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
 
   /sirv/2.0.2:
     resolution: {integrity: sha512-4Qog6aE29nIjAOKe/wowFTxOdmbEZKb+3tsLljaBRzJwtqto0BChD2zzH0LhgCSXiI+V7X+Y45v14wBZQ1TK3w==}

--- a/src/node/plugin-mdx/index.ts
+++ b/src/node/plugin-mdx/index.ts
@@ -1,11 +1,16 @@
 import { Plugin } from 'vite';
 import { pluginMdxRollup } from './pluginMdxRollup';
 import { pluginMdxHMR } from './pluginMdxHmr';
+import { pluginMdxGit } from './pluginMdxGit';
 import { SiteConfig } from 'shared/types/index';
 
 export async function pluginMdx(
   config: SiteConfig,
   isServer: boolean
 ): Promise<Plugin[]> {
-  return [await pluginMdxRollup(config, isServer), pluginMdxHMR(config)];
+  return [
+    await pluginMdxRollup(config, isServer),
+    pluginMdxHMR(config),
+    pluginMdxGit()
+  ];
 }

--- a/src/node/plugin-mdx/pluginMdxGit.ts
+++ b/src/node/plugin-mdx/pluginMdxGit.ts
@@ -1,0 +1,36 @@
+import { Plugin } from 'vite';
+import { simpleGit } from 'simple-git';
+import { MD_REGEX } from '../../node/constants';
+
+export function pluginMdxGit(): Plugin {
+  const cache = new Map<string, string>();
+  const git = simpleGit();
+
+  // https://github.com/steveukx/git-js#git-log
+  async function getLastUpdatedTime(path: string) {
+    const { latest } = await git.log({ file: path });
+    return !latest ? '' : latest.date;
+  }
+
+  return <Plugin>{
+    name: 'vite-plugin-mdx-git',
+    async transform(code, id) {
+      if (!MD_REGEX.test(id)) return code;
+
+      let lastUpdatedTime = '';
+      if (cache.has(id)) {
+        lastUpdatedTime = id;
+      } else {
+        const rawTime = await getLastUpdatedTime(id);
+        lastUpdatedTime = new Date(rawTime).toLocaleString();
+        cache.set(id, lastUpdatedTime);
+      }
+
+      code = code.concat(`
+        \n
+export const lastUpdatedTime = "${lastUpdatedTime}"
+      `);
+      return code;
+    }
+  };
+}

--- a/src/node/plugin-mdx/pluginMdxGit.ts
+++ b/src/node/plugin-mdx/pluginMdxGit.ts
@@ -19,7 +19,7 @@ export function pluginMdxGit(): Plugin {
 
       let lastUpdatedTime = '';
       if (cache.has(id)) {
-        lastUpdatedTime = id;
+        lastUpdatedTime = cache.get(id)!;
       } else {
         const rawTime = await getLastUpdatedTime(id);
         lastUpdatedTime = new Date(rawTime).toLocaleString();

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -173,6 +173,7 @@ export interface PageData {
   siteData: SiteData<DefaultTheme.Config>;
   pagePath: string;
   relativePagePath: string;
+  lastUpdatedTime: string;
   title?: string;
   meta?: FrontMatterMeta;
   description?: string;

--- a/src/theme-default/components/DocFooter/index.tsx
+++ b/src/theme-default/components/DocFooter/index.tsx
@@ -4,9 +4,9 @@ import { useEditLink, usePrevNextPage } from '../../logic';
 import { normalizeHref } from '../../logic/index';
 
 export function DocFooter() {
-  const { siteData, relativePagePath } = usePageData();
+  const { siteData, relativePagePath, lastUpdatedTime } = usePageData();
   const { prevPage, nextPage } = usePrevNextPage(siteData);
-  const { editLink: rawEditLink } = siteData.themeConfig;
+  const { editLink: rawEditLink, lastUpdatedText } = siteData.themeConfig;
   const editLink = useEditLink(rawEditLink!, relativePagePath);
 
   return (
@@ -20,17 +20,16 @@ export function DocFooter() {
           </div>
         ) : null}
 
-        {/* TODO */}
-        {/* <div className={styles.lastUpdated}>
-          {lastUpdatedText ? (
+        <div className={styles.lastUpdated}>
+          {
             <>
               <p className={styles.lastUpdated}>
-                {editLink?.text || 'Last Updated: '}
+                {`${lastUpdatedText ?? 'Last Updated'}: `}
               </p>
-              <span>{}</span>
+              <span>{lastUpdatedTime}</span>
             </>
-          ) : null}
-        </div> */}
+          }
+        </div>
       </div>
 
       <div className={styles.prevNext}>


### PR DESCRIPTION
# Description

Supporting showing last updated time for md(x) file via adding a vite plugin.

## Related Issue

#22

## Additional Content

A new devDependency [`simple-git`](https://github.com/steveukx/git-js) is being added.

Maybe it's not a best practice, but I couldn't find a way to get the whole file path of md(x) in the `@mdx-js/rollup` transform of md(x)
