### PR TITLE
fix: home button jump to github

### DIFF
--- a/packages/island/src/shared/utils/index.ts
+++ b/packages/island/src/shared/utils/index.ts
@@ -7,7 +7,7 @@ export const cleanUrl = (url: string): string =>
 export const inBrowser = () => typeof window !== 'undefined';
 
 export function addLeadingSlash(url: string) {
-  return url.charAt(0) === '/' ? url : '/' + url;
+  return url.charAt(0) === '/' || url.startsWith('https') ? url : '/' + url;
 }
 
 export function removeTrailingSlash(url: string) {


### PR DESCRIPTION
修复首页github地址 跳转不了 