### PR TITLE
fix: spa route leave api layout

### DIFF
--- a/packages/island/src/theme-default/layout/APILayout/index.tsx
+++ b/packages/island/src/theme-default/layout/APILayout/index.tsx
@@ -30,7 +30,7 @@ export function APILayout() {
       );
       return {
         ...item,
-        headers: (pageModule?.toc as Header[]).filter(
+        headers: (pageModule?.toc as Header[] | undefined)?.filter(
           (header) => header.depth === 2
         )
       };


### PR DESCRIPTION
spa 模式下，从 api pageType: 'api' 切到其他导航栏的时候，由于 APILayout 内部先重新渲染了一次
```ts
 const { subModules: apiPageModules = [] } = usePageData();
  const { pathname } = useLocation();
  const { items: apiSidebarGroups } = useSidebarData(pathname);
```
`usePageData` 拿到的 `pageType` 还是 api
但是 `useSidebarData` 已经是如 getting-start 了
导致 ` (pageModule?.toc as Header[])` 实际为 `undefined`，从 `undefined` 上取值

会使得页面崩溃，稳定复现～

这个是简单的修复，能从根源解决当然更好
