### PR TITLE
fix(remark-toc): support display emphasis and strong in toc

### DIFF
--- a/packages/island/src/node/plugin-mdx/remarkPlugins/toc.ts
+++ b/packages/island/src/node/plugin-mdx/remarkPlugins/toc.ts
@@ -14,7 +14,7 @@ interface TocItem {
 }
 
 interface ChildNode {
-  type: 'link' | 'text' | 'inlineCode';
+  type: 'link' | 'text' | 'inlineCode' | 'emphasis' | 'strong';
   value: string;
   children?: ChildNode[];
 }
@@ -42,10 +42,21 @@ export const remarkPluginToc: Plugin<[], Root> = () => {
       if (node.depth > 1 && node.depth < 5) {
         const originText = node.children
           .map((child: ChildNode) => {
-            if (child.type === 'link') {
-              return child.children?.map((item) => item.value).join('');
-            } else {
-              return child.value;
+            switch (child.type) {
+              // child with value
+              case 'text':
+              case 'inlineCode':
+                return child.value;
+
+              // child without value, but can get value from children property
+              case 'emphasis':
+              case 'strong':
+              case 'link':
+                return child.children?.map((c) => c.value).join('') || '';
+
+              // child without value and can not get value from children property
+              default:
+                return '';
             }
           })
           .join('');


### PR DESCRIPTION
Fix the problem that toc does not display the corresponding text when emphasis and strong are used in the title.

![image](https://user-images.githubusercontent.com/63829979/210766237-bbb3b5a8-84eb-4f69-8422-899ecc345901.png)

![image](https://user-images.githubusercontent.com/63829979/210766294-41eca81d-8f2d-4e41-ac6a-a92f009c1adb.png)
