### PR TITLE
fix(plugin-routes): :bug: Reload only modules that match the extension

### DIFF
--- a/packages/island/src/node/plugin-routes/RouteService.ts
+++ b/packages/island/src/node/plugin-routes/RouteService.ts
@@ -137,4 +137,8 @@ ${this.#routeData
 ];
 `;
   }
+
+  getExtensions() {
+    return this.#extensions;
+  }
 }


### PR DESCRIPTION
1. Adding or deleting some modules that do not match the extension will also cause the Island:routes module to reload.
2. Can you consider the file name of a specific prefix as a convention page in the future, such as _index.md and $_home.md, so as to avoid directory changes such as ‘dist’, which will also cause reloading.